### PR TITLE
Add code-coverage badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ "**" ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,15 +296,9 @@ jobs:
           path: coverage/badge.svg
 
       - name: Publish badge
-        uses: ncipollo/release-action@v1.18.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          tag: badges
-          name: Badges
-          allowUpdates: true
-          replaceArtifacts: true
-          artifacts: coverage/badge.svg
-          artifactContentType: image/svg+xml
-          makeLatest: false
+          folder: coverage
 
       
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,6 +257,12 @@ jobs:
           show-annotations: "warning"
           minimum-ratio: 1
 
+      - name: Upload current coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage (ubuntu current)
+          path: coverage/lcov.info
+
   coverage-badge:
     name: Create coverage badge
     # if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') }}
@@ -269,27 +275,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: cpp-binaries (ubuntu-latest - Debug)
-          path: ./build
+          name: coverage (ubuntu current)
+          path: ./coverage
 
-      - name: Install coverage dependencies
+      - name: Install dependencies
         run: |
           sudo apt-get update 
           sudo apt-get install -y lcov
-
-      - name: Set properties
-        run: |
-          chmod -R +x build/*
-          chmod -R +x build/**/*
-
-      - name: Run tests
-        run: |
-          ctest --test-dir build
-
-      - name: Get coverage report
-        run: |
-          mkdir -p coverage
-          lcov --capture --directory . --output-file coverage/lcov.info --ignore-errors mismatch
 
       - name: Get coverage percentage
         id: coverage
@@ -304,7 +296,7 @@ jobs:
           path: coverage/badge.svg
 
       - name: Publish badge
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.18.0
         with:
           tag: badges
           name: Badges

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,3 +256,63 @@ jobs:
           send-summary-comment: true
           show-annotations: "warning"
           minimum-ratio: 1
+
+  coverage-badge:
+    name: Create coverage badge
+    # if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') }}
+    needs: coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: cpp-binaries (ubuntu-latest - Debug)
+          path: ./build
+
+      - name: Install coverage dependencies
+        run: |
+          sudo apt-get update 
+          sudo apt-get install -y lcov
+
+      - name: Set properties
+        run: |
+          chmod -R +x build/*
+          chmod -R +x build/**/*
+
+      - name: Run tests
+        run: |
+          ctest --test-dir build
+
+      - name: Get coverage report
+        run: |
+          mkdir -p coverage
+          lcov --capture --directory . --output-file coverage/lcov.info --ignore-errors mismatch
+
+      - name: Get coverage percentage
+        id: coverage
+        run: |
+          echo pct=$(lcov --list coverage/lcov.info | grep -oP 'Total:\|\K[0-9.]+%')
+
+      - name: Generate badge
+        uses: emibcn/badge-action@v1
+        with:
+          label: Code Coverage
+          status: ${{ steps.coverage.outputs.pct }}
+          path: coverage/badge.svg
+
+      - name: Publish badge
+        uses: ncipollo/release-action@v1
+        with:
+          tag: badges
+          name: Badges
+          allowUpdates: true
+          replaceArtifacts: true
+          artifacts: coverage/badge.svg
+          artifactContentType: image/svg+xml
+          makeLatest: false
+
+      
+


### PR DESCRIPTION
- [ ] Add automatic generation of a code-ccoverage status badge
     - [ ] badge shall only be created on push / pull-request to main
- [ ] Add badge to README